### PR TITLE
Add Tailwind Typography plugin and update blog styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@astrojs/tailwind": "^6.0.0",
     "@iconify-json/ion": "^1.2.1",
     "@iconify-json/mdi": "^1.2.1",
+    "@tailwindcss/typography": "^0.5.16",
     "@types/jest": "^29.5.14",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^22.13.11",

--- a/src/pages/blog/[post].astro
+++ b/src/pages/blog/[post].astro
@@ -125,57 +125,12 @@ const formattedUpdatedDate = updatedDate
   }
 
   <section class="my-12">
-    <div class="prose dark:prose-invert container max-w-3xl">
+    <div class="prose prose-lg dark:prose-invert container max-w-3xl">
       <Content />
     </div>
   </section>
 </DefaultLayout>
 
 <style lang="scss">
-  .prose {
-    @apply text-lg leading-relaxed;
-
-    :global(h2) {
-      @apply text-2xl font-bold mt-8 mb-4;
-    }
-
-    :global(h3) {
-      @apply text-xl font-bold mt-6 mb-3;
-    }
-
-    :global(p) {
-      @apply mb-4;
-    }
-
-    :global(ul, ol) {
-      @apply mb-4 pl-6;
-    }
-
-    :global(li) {
-      @apply mb-1;
-    }
-
-    :global(blockquote) {
-      @apply border-l-4 border-neutral-300 dark:border-neutral-700 pl-4 italic;
-    }
-
-    :global(a) {
-      color: var(--action-color);
-      text-decoration: underline;
-
-      &:hover,
-      &:focus {
-        color: var(--action-color-state);
-        text-decoration: none;
-      }
-    }
-
-    :global(pre) {
-      @apply p-4 rounded-lg overflow-x-auto;
-    }
-
-    :global(img) {
-      @apply max-w-full rounded-lg my-6;
-    }
-  }
+  /* Removing custom prose styles as we're now using Tailwind Typography */
 </style>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,6 +4,6 @@ module.exports = {
   theme: {
     extend: {},
   },
-  plugins: [],
+  plugins: [require('@tailwindcss/typography')],
   darkMode: ['class', '.darkmode'],
 }


### PR DESCRIPTION
- Added '@tailwindcss/typography' to package.json and configured it in tailwind.config.js.
- Removed custom prose styles from the blog post page in favor of Tailwind Typography for improved text styling.